### PR TITLE
Handle return types for ubus requests that has list and UBUS_OK.

### DIFF
--- a/src/ubus/protocol.py
+++ b/src/ubus/protocol.py
@@ -218,6 +218,8 @@ class Ubus:
             if isinstance(result, dict): # got payload, passing directly
                 return result
             if isinstance(result, list): # got list, first one for error code, second for payload
+                if len(result) == 1 and (UbusError(result[0]) == UbusError.UBUS_STATUS_OK):
+                    return result
                 if len(result) == 1:
                     error = UbusError(result[0])
                     raise UbusException("Got error %s" % error)


### PR DESCRIPTION
There are some requests that return a single list entry and the status is UBUS_STATUS_OK.
I have made changes so that the library does not crash. Can you integrate this into your library ?

